### PR TITLE
Use a symbol instead of a string for the route

### DIFF
--- a/app/views/decidim/navbar_links/admin/navbar_links/index.html.erb
+++ b/app/views/decidim/navbar_links/admin/navbar_links/index.html.erb
@@ -30,7 +30,7 @@
               </td>
               <td class="table-list__actions">
                 <% if allowed_to? :update, :navbar_link %>
-                  <%= icon_link_to "pencil", ["edit", navbar_link], t("actions.edit", scope: "decidim.admin"), class: "action-icon--edit", method: :get, data: {} %>
+                  <%= icon_link_to "pencil", [:edit, navbar_link], t("actions.edit", scope: "decidim.admin"), class: "action-icon--edit", method: :get, data: {} %>
                 <% end %>
                 <% if allowed_to? :destroy, :navbar_link %>
                   <%= icon_link_to "circle-x", navbar_link, t("actions.destroy", scope: "decidim.admin"), class: "action-icon--remove", method: :delete, data: { confirm: t("actions.confirm_destroy", scope: "decidim.admin") } %>


### PR DESCRIPTION
It is not possible to use strings in `polymorphic_url` (and thus, `icon_link_to`) anymore, since this Rails commit: https://github.com/rails/rails/commit/c4c21a9f8d7c9c8ca6570bdb82d64e2dc860e62c
This affects Rails versions >= 5.2.4.6

The corresponding error stack trace that is fixed by this PR:
```
I, [2021-06-08T12:10:42.184395 #1]  INFO -- : [2f6aee28-e892-4e9e-8bf8-b24c77555f74] Started GET "/admin/navbar_links" for ::ffff:83.76.89.34 at 2021-06-08 12:10:42 +0200
I, [2021-06-08T12:10:42.243103 #1]  INFO -- : [2f6aee28-e892-4e9e-8bf8-b24c77555f74] Processing by Decidim::NavbarLinks::Admin::NavbarLinksController#index as HTML
I, [2021-06-08T12:10:42.245249 #1]  INFO -- : [2f6aee28-e892-4e9e-8bf8-b24c77555f74]   Rendering bundle/ruby/2.7.0/bundler/gems/decidim-module-navbar_links-1d1ef6eefa40/app/views/decidim/navbar_links/admin/navbar_links/index.html.erb within layouts/decidim/admin/settings
I, [2021-06-08T12:10:42.273117 #1]  INFO -- : [2f6aee28-e892-4e9e-8bf8-b24c77555f74]   Rendered bundle/ruby/2.7.0/bundler/gems/decidim-module-navbar_links-1d1ef6eefa40/app/views/decidim/navbar_links/admin/navbar_links/index.html.erb within layouts/decidim/admin/settings (27.7ms)
I, [2021-06-08T12:10:42.273663 #1]  INFO -- : [2f6aee28-e892-4e9e-8bf8-b24c77555f74] Completed 500 Internal Server Error in 30ms (ActiveRecord: 9.6ms)
F, [2021-06-08T12:10:42.275861 #1] FATAL -- : [2f6aee28-e892-4e9e-8bf8-b24c77555f74]   
F, [2021-06-08T12:10:42.275925 #1] FATAL -- : [2f6aee28-e892-4e9e-8bf8-b24c77555f74] ActionView::Template::Error (Please use symbols for polymorphic route arguments.):
F, [2021-06-08T12:10:42.276130 #1] FATAL -- : [2f6aee28-e892-4e9e-8bf8-b24c77555f74]     30:               </td>
[2f6aee28-e892-4e9e-8bf8-b24c77555f74]     31:               <td class="table-list__actions">
[2f6aee28-e892-4e9e-8bf8-b24c77555f74]     32:                 <% if allowed_to? :update, :navbar_link %>
[2f6aee28-e892-4e9e-8bf8-b24c77555f74]     33:                   <%= icon_link_to "pencil", ["edit", navbar_link], t("actions.edit", scope: "decidim.admin"), class: "action-icon--edit", method: :get, data: {} %>
[2f6aee28-e892-4e9e-8bf8-b24c77555f74]     34:                 <% end %>
[2f6aee28-e892-4e9e-8bf8-b24c77555f74]     35:                 <% if allowed_to? :destroy, :navbar_link %>
[2f6aee28-e892-4e9e-8bf8-b24c77555f74]     36:                   <%= icon_link_to "circle-x", navbar_link, t("actions.destroy", scope: "decidim.admin"), class: "action-icon--remove", method: :delete, data: { confirm: t("actions.confirm_destroy", scope: "decidim.admin") } %>
F, [2021-06-08T12:10:42.276173 #1] FATAL -- : [2f6aee28-e892-4e9e-8bf8-b24c77555f74]   
F, [2021-06-08T12:10:42.276278 #1] FATAL -- : [2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionpack-5.2.6/lib/action_dispatch/routing/polymorphic_routes.rb:296:in `block in handle_list'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionpack-5.2.6/lib/action_dispatch/routing/polymorphic_routes.rb:291:in `map'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionpack-5.2.6/lib/action_dispatch/routing/polymorphic_routes.rb:291:in `handle_list'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionpack-5.2.6/lib/action_dispatch/routing/polymorphic_routes.rb:219:in `polymorphic_method'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionpack-5.2.6/lib/action_dispatch/routing/polymorphic_routes.rb:140:in `polymorphic_path'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionview-5.2.6/lib/action_view/routing_url_for.rb:103:in `url_for'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionview-5.2.6/lib/action_view/helpers/url_helper.rb:202:in `link_to'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/decidim-admin-0.24.2/app/helpers/decidim/admin/icon_link_helper.rb:18:in `icon_link_to'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/bundler/gems/decidim-module-navbar_links-1d1ef6eefa40/app/views/decidim/navbar_links/admin/navbar_links/index.html.erb:33:in `block in _bundle_ruby_______bundler_gems_decidim_module_navbar_links__d_ef_eefa___app_views_decidim_navbar_links_admin_navbar_links_index_html_erb__665109863037634595_30856000'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/activerecord-5.2.6/lib/active_record/relation/delegation.rb:71:in `each'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/activerecord-5.2.6/lib/active_record/relation/delegation.rb:71:in `each'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/bundler/gems/decidim-module-navbar_links-1d1ef6eefa40/app/views/decidim/navbar_links/admin/navbar_links/index.html.erb:20:in `_bundle_ruby_______bundler_gems_decidim_module_navbar_links__d_ef_eefa___app_views_decidim_navbar_links_admin_navbar_links_index_html_erb__665109863037634595_30856000'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionview-5.2.6/lib/action_view/template.rb:159:in `block in render'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/activesupport-5.2.6/lib/active_support/notifications.rb:170:in `instrument'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionview-5.2.6/lib/action_view/template.rb:354:in `instrument_render_template'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionview-5.2.6/lib/action_view/template.rb:157:in `render'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionview-5.2.6/lib/action_view/renderer/template_renderer.rb:54:in `block (2 levels) in render_template'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionview-5.2.6/lib/action_view/renderer/abstract_renderer.rb:44:in `block in instrument'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/activesupport-5.2.6/lib/active_support/notifications.rb:168:in `block in instrument'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/activesupport-5.2.6/lib/active_support/notifications/instrumenter.rb:23:in `instrument'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/activesupport-5.2.6/lib/active_support/notifications.rb:168:in `instrument'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionview-5.2.6/lib/action_view/renderer/abstract_renderer.rb:43:in `instrument'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionview-5.2.6/lib/action_view/renderer/template_renderer.rb:53:in `block in render_template'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionview-5.2.6/lib/action_view/renderer/template_renderer.rb:61:in `render_with_layout'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionview-5.2.6/lib/action_view/renderer/template_renderer.rb:52:in `render_template'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionview-5.2.6/lib/action_view/renderer/template_renderer.rb:16:in `render'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionview-5.2.6/lib/action_view/renderer/renderer.rb:44:in `render_template'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionview-5.2.6/lib/action_view/renderer/renderer.rb:25:in `render'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionview-5.2.6/lib/action_view/rendering.rb:103:in `_render_template'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionpack-5.2.6/lib/action_controller/metal/streaming.rb:219:in `_render_template'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionview-5.2.6/lib/action_view/rendering.rb:84:in `render_to_body'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionpack-5.2.6/lib/action_controller/metal/rendering.rb:52:in `render_to_body'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionpack-5.2.6/lib/action_controller/metal/renderers.rb:142:in `render_to_body'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionpack-5.2.6/lib/abstract_controller/rendering.rb:25:in `render'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionpack-5.2.6/lib/action_controller/metal/rendering.rb:36:in `render'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionpack-5.2.6/lib/action_controller/metal/instrumentation.rb:46:in `block (2 levels) in render'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/activesupport-5.2.6/lib/active_support/core_ext/benchmark.rb:14:in `block in ms'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] /opt/rh/rh-ruby27/root/usr/share/ruby/benchmark.rb:308:in `realtime'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/activesupport-5.2.6/lib/active_support/core_ext/benchmark.rb:14:in `ms'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionpack-5.2.6/lib/action_controller/metal/instrumentation.rb:46:in `block in render'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionpack-5.2.6/lib/action_controller/metal/instrumentation.rb:87:in `cleanup_view_runtime'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/activerecord-5.2.6/lib/active_record/railties/controller_runtime.rb:31:in `cleanup_view_runtime'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionpack-5.2.6/lib/action_controller/metal/instrumentation.rb:45:in `render'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/wicked_pdf-1.4.0/lib/wicked_pdf/pdf_helper.rb:46:in `call'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/wicked_pdf-1.4.0/lib/wicked_pdf/pdf_helper.rb:46:in `render_with_wicked_pdf'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/wicked_pdf-1.4.0/lib/wicked_pdf/pdf_helper.rb:30:in `render'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionpack-5.2.6/lib/action_controller/metal/implicit_render.rb:35:in `default_render'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionpack-5.2.6/lib/action_controller/metal/basic_implicit_render.rb:6:in `block in send_action'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionpack-5.2.6/lib/action_controller/metal/basic_implicit_render.rb:6:in `tap'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionpack-5.2.6/lib/action_controller/metal/basic_implicit_render.rb:6:in `send_action'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionpack-5.2.6/lib/abstract_controller/base.rb:194:in `process_action'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionpack-5.2.6/lib/action_controller/metal/rendering.rb:30:in `process_action'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionpack-5.2.6/lib/abstract_controller/callbacks.rb:42:in `block in process_action'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/activesupport-5.2.6/lib/active_support/callbacks.rb:109:in `block in run_callbacks'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/activesupport-5.2.6/lib/active_support/core_ext/time/zones.rb:66:in `use_zone'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/decidim-core-0.24.2/app/controllers/concerns/decidim/use_organization_time_zone.rb:21:in `use_organization_time_zone'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/activesupport-5.2.6/lib/active_support/callbacks.rb:118:in `block in run_callbacks'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/i18n-1.8.10/lib/i18n.rb:314:in `with_locale'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/decidim-core-0.24.2/app/controllers/concerns/decidim/locale_switcher.rb:24:in `switch_locale'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/activesupport-5.2.6/lib/active_support/callbacks.rb:118:in `block in run_callbacks'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/activesupport-5.2.6/lib/active_support/callbacks.rb:136:in `run_callbacks'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionpack-5.2.6/lib/abstract_controller/callbacks.rb:41:in `process_action'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionpack-5.2.6/lib/action_controller/metal/rescue.rb:22:in `process_action'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionpack-5.2.6/lib/action_controller/metal/instrumentation.rb:34:in `block in process_action'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/activesupport-5.2.6/lib/active_support/notifications.rb:168:in `block in instrument'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/activesupport-5.2.6/lib/active_support/notifications/instrumenter.rb:23:in `instrument'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/activesupport-5.2.6/lib/active_support/notifications.rb:168:in `instrument'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionpack-5.2.6/lib/action_controller/metal/instrumentation.rb:32:in `process_action'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionpack-5.2.6/lib/action_controller/metal/params_wrapper.rb:256:in `process_action'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/activerecord-5.2.6/lib/active_record/railties/controller_runtime.rb:24:in `process_action'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionpack-5.2.6/lib/abstract_controller/base.rb:134:in `process'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionview-5.2.6/lib/action_view/rendering.rb:32:in `process'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionpack-5.2.6/lib/action_controller/metal.rb:191:in `dispatch'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionpack-5.2.6/lib/action_controller/metal.rb:252:in `dispatch'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionpack-5.2.6/lib/action_dispatch/routing/route_set.rb:52:in `dispatch'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionpack-5.2.6/lib/action_dispatch/routing/route_set.rb:34:in `serve'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionpack-5.2.6/lib/action_dispatch/journey/router.rb:52:in `block in serve'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionpack-5.2.6/lib/action_dispatch/journey/router.rb:35:in `each'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionpack-5.2.6/lib/action_dispatch/journey/router.rb:35:in `serve'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionpack-5.2.6/lib/action_dispatch/routing/route_set.rb:840:in `call'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/railties-5.2.6/lib/rails/engine.rb:524:in `call'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/railties-5.2.6/lib/rails/railtie.rb:190:in `public_send'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/railties-5.2.6/lib/rails/railtie.rb:190:in `method_missing'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionpack-5.2.6/lib/action_dispatch/routing/mapper.rb:19:in `block in <class:Constraints>'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionpack-5.2.6/lib/action_dispatch/routing/mapper.rb:48:in `serve'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionpack-5.2.6/lib/action_dispatch/journey/router.rb:52:in `block in serve'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionpack-5.2.6/lib/action_dispatch/journey/router.rb:35:in `each'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionpack-5.2.6/lib/action_dispatch/journey/router.rb:35:in `serve'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionpack-5.2.6/lib/action_dispatch/routing/route_set.rb:840:in `call'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/railties-5.2.6/lib/rails/engine.rb:524:in `call'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/railties-5.2.6/lib/rails/railtie.rb:190:in `public_send'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/railties-5.2.6/lib/rails/railtie.rb:190:in `method_missing'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionpack-5.2.6/lib/action_dispatch/routing/mapper.rb:19:in `block in <class:Constraints>'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionpack-5.2.6/lib/action_dispatch/routing/mapper.rb:48:in `serve'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionpack-5.2.6/lib/action_dispatch/journey/router.rb:52:in `block in serve'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionpack-5.2.6/lib/action_dispatch/journey/router.rb:35:in `each'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionpack-5.2.6/lib/action_dispatch/journey/router.rb:35:in `serve'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionpack-5.2.6/lib/action_dispatch/routing/route_set.rb:840:in `call'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/batch-loader-1.5.0/lib/batch_loader/middleware.rb:11:in `call'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/rack-attack-6.5.0/lib/rack/attack.rb:113:in `call'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/omniauth-1.9.1/lib/omniauth/strategy.rb:192:in `call!'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/omniauth-1.9.1/lib/omniauth/strategy.rb:169:in `call'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/omniauth-1.9.1/lib/omniauth/strategy.rb:192:in `call!'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/omniauth-1.9.1/lib/omniauth/strategy.rb:169:in `call'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/omniauth-1.9.1/lib/omniauth/strategy.rb:192:in `call!'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/omniauth-1.9.1/lib/omniauth/strategy.rb:169:in `call'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/omniauth-1.9.1/lib/omniauth/builder.rb:45:in `call'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/warden-1.2.9/lib/warden/manager.rb:36:in `block in call'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/warden-1.2.9/lib/warden/manager.rb:34:in `catch'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/warden-1.2.9/lib/warden/manager.rb:34:in `call'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/decidim-core-0.24.2/app/middleware/decidim/strip_x_forwarded_host.rb:11:in `call'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/decidim-core-0.24.2/app/middleware/decidim/current_organization.rb:21:in `call'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/rack-2.2.3/lib/rack/tempfile_reaper.rb:15:in `call'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/rack-2.2.3/lib/rack/etag.rb:27:in `call'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/rack-2.2.3/lib/rack/conditional_get.rb:27:in `call'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/rack-2.2.3/lib/rack/head.rb:12:in `call'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionpack-5.2.6/lib/action_dispatch/http/content_security_policy.rb:18:in `call'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/rack-2.2.3/lib/rack/session/abstract/id.rb:266:in `context'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/rack-2.2.3/lib/rack/session/abstract/id.rb:260:in `call'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionpack-5.2.6/lib/action_dispatch/middleware/cookies.rb:670:in `call'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionpack-5.2.6/lib/action_dispatch/middleware/callbacks.rb:28:in `block in call'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/activesupport-5.2.6/lib/active_support/callbacks.rb:98:in `run_callbacks'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionpack-5.2.6/lib/action_dispatch/middleware/callbacks.rb:26:in `call'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionpack-5.2.6/lib/action_dispatch/middleware/debug_exceptions.rb:61:in `call'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionpack-5.2.6/lib/action_dispatch/middleware/show_exceptions.rb:33:in `call'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/railties-5.2.6/lib/rails/rack/logger.rb:38:in `call_app'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/railties-5.2.6/lib/rails/rack/logger.rb:26:in `block in call'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/activesupport-5.2.6/lib/active_support/tagged_logging.rb:71:in `block in tagged'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/activesupport-5.2.6/lib/active_support/tagged_logging.rb:28:in `tagged'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/activesupport-5.2.6/lib/active_support/tagged_logging.rb:71:in `tagged'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/railties-5.2.6/lib/rails/rack/logger.rb:26:in `call'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionpack-5.2.6/lib/action_dispatch/middleware/remote_ip.rb:81:in `call'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/request_store-1.5.0/lib/request_store/middleware.rb:19:in `call'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionpack-5.2.6/lib/action_dispatch/middleware/request_id.rb:27:in `call'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/rack-2.2.3/lib/rack/method_override.rb:24:in `call'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/redirector-1.1.7/lib/redirector/middleware.rb:25:in `response'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/redirector-1.1.7/lib/redirector/middleware.rb:10:in `call'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/activesupport-5.2.6/lib/active_support/cache/strategy/local_cache_middleware.rb:29:in `call'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/actionpack-5.2.6/lib/action_dispatch/middleware/executor.rb:14:in `call'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/rack-2.2.3/lib/rack/sendfile.rb:110:in `call'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/prometheus_exporter-0.7.0/lib/prometheus_exporter/middleware.rb:34:in `call'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/rack-cors-1.1.1/lib/rack/cors.rb:100:in `call'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/railties-5.2.6/lib/rails/engine.rb:524:in `call'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/puma-5.3.1/lib/puma/configuration.rb:249:in `call'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/puma-5.3.1/lib/puma/request.rb:76:in `block in handle_request'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/puma-5.3.1/lib/puma/thread_pool.rb:338:in `with_force_shutdown'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/puma-5.3.1/lib/puma/request.rb:75:in `handle_request'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/puma-5.3.1/lib/puma/server.rb:437:in `process_client'
[2f6aee28-e892-4e9e-8bf8-b24c77555f74] bundle/ruby/2.7.0/gems/puma-5.3.1/lib/puma/thread_pool.rb:145:in `block in spawn_thread'
I, [2021-06-08T12:10:42.278267 #1]  INFO -- : [2f6aee28-e892-4e9e-8bf8-b24c77555f74] Processing by Decidim::ErrorsController#internal_server_error as HTML
I, [2021-06-08T12:10:42.319788 #1]  INFO -- : [2f6aee28-e892-4e9e-8bf8-b24c77555f74]   Rendering bundle/ruby/2.7.0/gems/decidim-core-0.24.2/app/views/decidim/errors/internal_server_error.html.erb within layouts/decidim/application
I, [2021-06-08T12:10:42.320480 #1]  INFO -- : [2f6aee28-e892-4e9e-8bf8-b24c77555f74]   Rendered bundle/ruby/2.7.0/gems/decidim-core-0.24.2/app/views/decidim/errors/internal_server_error.html.erb within layouts/decidim/application (0.5ms)
I, [2021-06-08T12:10:42.409692 #1]  INFO -- : [2f6aee28-e892-4e9e-8bf8-b24c77555f74]   Rendered bundle/ruby/2.7.0/gems/decidim-decidim_awesome-0.7.0/app/views/layouts/decidim/decidim_awesome/_custom_styles.html.erb (0.1ms)
I, [2021-06-08T12:10:42.410749 #1]  INFO -- : [2f6aee28-e892-4e9e-8bf8-b24c77555f74]   Rendered bundle/ruby/2.7.0/gems/decidim-core-0.24.2/app/views/layouts/decidim/_organization_colors.html.erb (0.1ms)
I, [2021-06-08T12:10:42.411580 #1]  INFO -- : [2f6aee28-e892-4e9e-8bf8-b24c77555f74]   Rendered layouts/decidim/_head_extra.html.erb (0.1ms)
I, [2021-06-08T12:10:42.414123 #1]  INFO -- : [2f6aee28-e892-4e9e-8bf8-b24c77555f74]   Rendered bundle/ruby/2.7.0/gems/decidim-decidim_awesome-0.7.0/app/views/layouts/decidim/decidim_awesome/_awesome_config.html.erb (2.1ms)
I, [2021-06-08T12:10:42.414435 #1]  INFO -- : [2f6aee28-e892-4e9e-8bf8-b24c77555f74]   Rendered bundle/ruby/2.7.0/gems/decidim-decidim_awesome-0.7.0/app/views/v0.24/layouts/decidim/_head.html.erb (44.5ms)
I, [2021-06-08T12:10:42.414560 #1]  INFO -- : [2f6aee28-e892-4e9e-8bf8-b24c77555f74]   Rendered bundle/ruby/2.7.0/gems/decidim-decidim_awesome-0.7.0/app/views/layouts/decidim/_head.html.erb (44.9ms)
I, [2021-06-08T12:10:42.416496 #1]  INFO -- : [2f6aee28-e892-4e9e-8bf8-b24c77555f74]   Rendered bundle/ruby/2.7.0/gems/decidim-core-0.24.2/app/views/layouts/decidim/_impersonation_warning.html.erb (1.3ms)
I, [2021-06-08T12:10:42.418186 #1]  INFO -- : [2f6aee28-e892-4e9e-8bf8-b24c77555f74]   Rendered bundle/ruby/2.7.0/gems/decidim-core-0.24.2/app/views/layouts/decidim/_cookie_warning.html.erb (1.2ms)
I, [2021-06-08T12:10:42.419320 #1]  INFO -- : [2f6aee28-e892-4e9e-8bf8-b24c77555f74]   Rendered bundle/ruby/2.7.0/gems/decidim-core-0.24.2/app/views/layouts/decidim/_omnipresent_banner.html.erb (0.6ms)
I, [2021-06-08T12:10:42.421269 #1]  INFO -- : [2f6aee28-e892-4e9e-8bf8-b24c77555f74]   Rendered bundle/ruby/2.7.0/gems/decidim-core-0.24.2/app/views/layouts/decidim/_timeout_modal.html.erb (1.5ms)
I, [2021-06-08T12:10:42.426779 #1]  INFO -- : [2f6aee28-e892-4e9e-8bf8-b24c77555f74]   Rendered bundle/ruby/2.7.0/gems/decidim-core-0.24.2/app/views/layouts/decidim/_logo.html.erb (4.1ms)
I, [2021-06-08T12:10:42.428309 #1]  INFO -- : [2f6aee28-e892-4e9e-8bf8-b24c77555f74]   Rendered bundle/ruby/2.7.0/gems/decidim-core-0.24.2/app/views/layouts/decidim/_topbar_search.html.erb (1.0ms)
I, [2021-06-08T12:10:42.428812 #1]  INFO -- : [2f6aee28-e892-4e9e-8bf8-b24c77555f74]   Rendered bundle/ruby/2.7.0/gems/decidim-core-0.24.2/app/views/layouts/decidim/_language_chooser.html.erb (0.1ms)
I, [2021-06-08T12:10:42.502743 #1]  INFO -- : [2f6aee28-e892-4e9e-8bf8-b24c77555f74]   Rendered bundle/ruby/2.7.0/gems/decidim-core-0.24.2/app/views/layouts/decidim/_user_menu.html.erb (2.0ms)
I, [2021-06-08T12:10:42.505249 #1]  INFO -- : [2f6aee28-e892-4e9e-8bf8-b24c77555f74]   Rendered bundle/ruby/2.7.0/gems/decidim-core-0.24.2/app/views/layouts/decidim/_user_menu.html.erb (1.7ms)
I, [2021-06-08T12:10:42.506089 #1]  INFO -- : [2f6aee28-e892-4e9e-8bf8-b24c77555f74]   Rendered bundle/ruby/2.7.0/gems/decidim-core-0.24.2/app/views/layouts/decidim/_admin_links.html.erb (0.2ms)
I, [2021-06-08T12:10:42.682392 #1]  INFO -- : [2f6aee28-e892-4e9e-8bf8-b24c77555f74]   Rendered bundle/ruby/2.7.0/gems/decidim-core-0.24.2/app/views/layouts/decidim/_social_media_links.html.erb (0.1ms)
I, [2021-06-08T12:10:42.682524 #1]  INFO -- : [2f6aee28-e892-4e9e-8bf8-b24c77555f74]   Rendered layouts/decidim/_main_footer.html.erb (64.7ms)
I, [2021-06-08T12:10:42.683500 #1]  INFO -- : [2f6aee28-e892-4e9e-8bf8-b24c77555f74]   Rendered bundle/ruby/2.7.0/gems/decidim-core-0.24.2/app/views/layouts/decidim/_mini_footer.html.erb (0.5ms)
I, [2021-06-08T12:10:42.683622 #1]  INFO -- : [2f6aee28-e892-4e9e-8bf8-b24c77555f74]   Rendered bundle/ruby/2.7.0/gems/decidim-core-0.24.2/app/views/layouts/decidim/_wrapper.html.erb (261.9ms)
I, [2021-06-08T12:10:42.684588 #1]  INFO -- : [2f6aee28-e892-4e9e-8bf8-b24c77555f74]   Rendered bundle/ruby/2.7.0/gems/decidim-core-0.24.2/app/views/decidim/shared/_confirm_modal.html.erb (0.5ms)
I, [2021-06-08T12:10:42.685118 #1]  INFO -- : [2f6aee28-e892-4e9e-8bf8-b24c77555f74]   Rendered bundle/ruby/2.7.0/gems/decidim-core-0.24.2/app/views/decidim/shared/_authorization_modal.html.erb (0.0ms)
I, [2021-06-08T12:10:42.687110 #1]  INFO -- : [2f6aee28-e892-4e9e-8bf8-b24c77555f74]   Rendered bundle/ruby/2.7.0/gems/decidim-core-0.24.2/app/views/layouts/decidim/_js_configuration.html.erb (1.6ms)
I, [2021-06-08T12:10:42.687303 #1]  INFO -- : [2f6aee28-e892-4e9e-8bf8-b24c77555f74]   Rendered bundle/ruby/2.7.0/gems/decidim-core-0.24.2/app/views/layouts/decidim/_application.html.erb (366.2ms)
I, [2021-06-08T12:10:42.687951 #1]  INFO -- : [2f6aee28-e892-4e9e-8bf8-b24c77555f74] Completed 500 Internal Server Error in 409ms (Views: 110.8ms | ActiveRecord: 278.5ms)
```